### PR TITLE
Include iLike in possible search types.

### DIFF
--- a/lib/turbo_ecto/services/build_search_query.ex
+++ b/lib/turbo_ecto/services/build_search_query.ex
@@ -35,6 +35,7 @@ defmodule Turbo.Ecto.Services.BuildSearchQuery do
 
   @search_types ~w(eq
                   like
+                  ilike
                   not_eq
                   cont
                   not_cont


### PR DESCRIPTION
Currently, `ilike` is missing from search types and as such ends up getting the same treatment as `like` which is incorrect. Seems that just adding it here resolves the issue.